### PR TITLE
Implement flickr tags in pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Settings
 Flickr Settings
 ---------------
 
-The following two settings are required. In order to set them up, you will need to set up a Flickr API key. You can do this by `creating an app on Flickr`_. If the blog is a personal blog, then apply for a non-commercial key. Once you've got your key and secret, add them to your `Pelican configuration`_.
+The following two settings are required. In order to set them up, you will need to set up a Flickr API key. You can do this by `creating an app on Flickr`_. If the blog is a personal blog, then apply for a non-commercial key. Once you've got your key and secret, add them apply `pelicanconf.py changes`_.
 
 ``FLICKR_API_KEY`` - The API key for your app to access the Flickr API. (Required)
 
@@ -95,21 +95,26 @@ A Flickr API token is only required if you want to access photos that are privat
 
 ``FLICKR_API_TOKEN`` - The API token to access the Flickr API. (Optional)
 
+pelicanconf.py changes
+----------------------
+
 pelicanconf.py may be get something like:
 
 .. code-block:: python
 
-FLICKR_API_KEY = ''
-FLICKR_API_SECRET = ''
-FLICKR_USER = ''
-FLICKR_TAG_CACHE_LOCATION = './tmp_flickr'
-FLICKR_TAG_TEMPLATE_NAME = 'images'
-FLICKR_TAG_PLACE_HOLDER_PICT = "/theme/images/place-holder.png"
-try:
-	from flickr_api.flickr_api import *
-except ImportError:
-	pass
-	
+    FLICKR_API_KEY = ''
+    FLICKR_API_SECRET = ''
+    FLICKR_USER = ''
+    FLICKR_TAG_CACHE_LOCATION = './tmp_flickr'
+    FLICKR_TAG_TEMPLATE_NAME = 'images'
+    FLICKR_TAG_PLACE_HOLDER_PICT = "/theme/images/place-holder.png"
+    try:
+	   from flickr_api import *
+    except ImportError:
+	   pass
+
+and create a file mamed flickr_api.py containing your key, secret and other settings
+
 Notes
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Settings
 
 .. code-block:: html
 
-    <p class="caption-container">
+    <spam class="caption-container">
         <a class="caption" href="{{url}}" target="_blank">
             <img src="{{raw_url}}"
                 alt="{{title}}"
@@ -66,7 +66,7 @@ Settings
                 {% endif %} />
         </a>
         <span class="caption-text muted">{{title}}</span>
-    </p>
+    </spam>
 
 ``FLICKR_TAG_CACHE_LOCATION`` - The cache location which stores the looked up photo information. This dramatically speeds up building of the site and permits you to do it offline as well. Defaults to `/tmp/com.chrisstreeter.flickrtag-images.cache` (Optional)
 
@@ -74,6 +74,9 @@ Settings
 
 ``FLICKR_TAG_IMAGE_SIZE`` - The size alias used if ``FLICKR_TAG_INCLUDE_DIMENSIONS`` is set to ``True``. Default is 'Medium 640'. See the `Flickr getSizes documentation`_ for the valid values. (Optional)
 
+``FLICKR_TAG_PLACE_HOLDER_PICT`` -  variable is mandatory in your config if you dont have ``FLICKR_API_KEY`` pointing to a local pict how serve as a placeholder
+
+``FLICKR_TAG_PLACE_HOLDER_LINK`` - link associated with placeholder pict Default to git repo of this plug-in
 
 Flickr Settings
 ---------------
@@ -92,7 +95,21 @@ A Flickr API token is only required if you want to access photos that are privat
 
 ``FLICKR_API_TOKEN`` - The API token to access the Flickr API. (Optional)
 
+pelicanconf.py may be get something like:
 
+.. code-block:: python
+
+FLICKR_API_KEY = ''
+FLICKR_API_SECRET = ''
+FLICKR_USER = ''
+FLICKR_TAG_CACHE_LOCATION = './tmp_flickr'
+FLICKR_TAG_TEMPLATE_NAME = 'images'
+FLICKR_TAG_PLACE_HOLDER_PICT = "/theme/images/place-holder.png"
+try:
+	from flickr_api.flickr_api import *
+except ImportError:
+	pass
+	
 Notes
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Settings
 
 .. code-block:: html
 
-    <spam class="caption-container">
+    <span class="caption-container">
         <a class="caption" href="{{url}}" target="_blank">
             <img src="{{raw_url}}"
                 alt="{{title}}"

--- a/pelican_flickrtag/__init__.py
+++ b/pelican_flickrtag/__init__.py
@@ -1,8 +1,1 @@
-__title__ = 'pelican-flickrtag'
-__version__ = '0.5.0'
-__author__ = 'Chris Streeter'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2014'
-
-
 from pelican_flickrtag.plugin import register

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -63,9 +63,9 @@ def size_for_alias(sizes, alias):
         alias = 'Medium'
     return [s for s in sizes if s['label'] == alias][0]
 
-def generic_replace(generator, type):
-    if type not in ('article', 'page'):
-        type = 'article'
+def generic_replace(generator, ct_type):
+    if ct_type not in ('article', 'page'):
+        ct_type = 'article'
 
 
     from jinja2 import Template
@@ -81,8 +81,8 @@ def generic_replace(generator, type):
     size_alias = generator.context.get('FLICKR_TAG_IMAGE_SIZE')
 
     photo_ids = set([])
-    logger.info('[flickrtag]: Parsing %ss for photo ids...' % type)
-    if type='article':
+    logger.info('[flickrtag]: Parsing %ss for photo ids...' % ct_type)
+    if ct_type == 'article':
         item_list = generator.articles
     else:
         item_list = generator.pages
@@ -90,7 +90,7 @@ def generic_replace(generator, type):
         for match in flickr_regex.findall(item._content):
             photo_ids.add(match[1])
 
-    logger.info('[flickrtag]: Found %d photo ids in the %ss' % len(photo_ids),type )
+    logger.info('[flickrtag]: Found %d photo ids in the %ss' % (len(photo_ids),ct_type) ) 
 
     try:
         with open(tmp_file, 'r') as f:
@@ -137,8 +137,8 @@ def generic_replace(generator, type):
     else:
         template = Template(default_template)
 
-    logger.info('[flickrtag]: Inserting photo information into %ss...' % type)
-    if type='article':
+    logger.info('[flickrtag]: Inserting photo information into %ss...' % ct_type)
+    if ct_type == 'article':
         item_list = generator.articles
     else:
         item_list = generator.pages

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -42,12 +42,12 @@ def setup_flickr(generator):
 
     generator.flickr_api_client = api_client
     try:
-        place_holder_pict = generator.settings(FLICKR_TAG_PLACE_HOLDER_PICT)
+        place_holder_pict = generator.settings['FLICKR_TAG_PLACE_HOLDER_PICT']
     except:
         logger.error ('[flickrtag]: FLICKR_TAG_PLACE_HOLDER_PICT variable is mandatory in your config')
 
     try:
-        place_holder_link = generator.settings(FLICKR_TAG_PLACE_HOLDER_LINK)
+        place_holder_link = generator.settings['FLICKR_TAG_PLACE_HOLDER_LINK']
     except:
         generator.settings.setdefault('FLICKR_TAG_PLACE_HOLDER_LINK','https://github.com/haum/pelican-flickrtag')        
         logger.warning ('[flickrtag]: FLICKR_TAG_PLACE_HOLDER_LINK is set to default')

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -13,7 +13,7 @@ import flickr as api_client
 from pelican import signals
 
 flickr_regex = re.compile(r'(\[flickr:id\=([0-9]+)\])')
-default_template = """<p class="caption-container">
+default_template = """<spam class="caption-container">
     <a class="caption" href="{{url}}" target="_blank">
         <img src="{{raw_url}}"
             alt="{{title}}"
@@ -25,7 +25,7 @@ default_template = """<p class="caption-container">
             {% endif %} />
     </a>
     <span class="caption-text muted">{{title}}</span>
-</p>"""
+</spam>"""
 
 logger = logging.getLogger(__name__)
 

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -136,7 +136,7 @@ def generic_replace(generator, ct_type):
                 photo_mapping[id] = {
                     'title': "Placeholder",
                     'raw_url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_PICT')
-                    'url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_LINK'),
+                    'url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_LINK')
                 }
 
         with open(tmp_file, 'w') as f:

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -12,7 +12,7 @@ import flickr as api_client
 
 from pelican import signals
 
-flickr_regex = re.compile(r'<p>(\[flickr:id\=([0-9]+)\])</p>')
+flickr_regex = re.compile(r'(\[flickr:id\=([0-9]+)\])')
 default_template = """<p class="caption-container">
     <a class="caption" href="{{url}}" target="_blank">
         <img src="{{raw_url}}"

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -13,7 +13,7 @@ import flickr as api_client
 from pelican import signals
 
 flickr_regex = re.compile(r'(\[flickr:id\=([0-9]+)\])')
-default_template = """<spam class="caption-container">
+default_template = """<span class="caption-container">
     <a class="caption" href="{{url}}" target="_blank">
         <img src="{{raw_url}}"
             alt="{{title}}"

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -149,7 +149,87 @@ def replace_article_tags(generator):
 
 
 def replace_page_tags(generator):
-    pass
+    from jinja2 import Template
+
+    api = generator.flickr_api_client
+    if api is None:
+        logger.error('[flickrtag]: Unable to get the Flickr API object')
+        return
+
+    tmp_file = generator.context.get('FLICKR_TAG_CACHE_LOCATION')
+
+    include_dimensions = generator.context.get('FLICKR_TAG_INCLUDE_DIMENSIONS')
+    size_alias = generator.context.get('FLICKR_TAG_IMAGE_SIZE')
+
+    photo_ids = set([])
+    logger.info('[flickrtag]: Parsing pages for photo ids...')
+    for page in generator.pages:
+        for match in flickr_regex.findall(page._content):
+            photo_ids.add(match[1])
+
+    logger.info('[flickrtag]: Found %d photo ids in the page' % len(photo_ids))
+
+    try:
+        with open(tmp_file, 'r') as f:
+            photo_mapping = pickle.load(f)
+    except (IOError, EOFError):
+        photo_mapping = {}
+    else:
+        # Get the difference of photo_ids and what have cached
+        cached_ids = set(photo_mapping.keys())
+        photo_ids = list(set(photo_ids) - cached_ids)
+
+    if photo_ids:
+        logger.info('[flickrtag]: Fetching photo information from Flickr...')
+        for id in photo_ids:
+            logger.info('[flickrtag]: Fetching photo information for %s' % id)
+            photo = api.Photo(id=id)
+            # Trigger the API call...
+            photo_mapping[id] = {
+                'title': photo.title,
+                'raw_url': url_for_alias(photo, size_alias),
+                'url': photo.url,
+            }
+
+            if include_dimensions:
+                sizes = photo.getSizes()
+                size = size_for_alias(sizes, size_alias)
+                photo_mapping[id]['width'] = size['width']
+                photo_mapping[id]['height'] = size['height']
+
+        with open(tmp_file, 'w') as f:
+            pickle.dump(photo_mapping, f)
+    else:
+        logger.info('[flickrtag]: Found pickled photo mapping')
+
+    # See if a custom template was provided
+    template_name = generator.context.get('FLICKR_TAG_TEMPLATE_NAME')
+    if template_name is not None:
+        # There's a custom template
+        try:
+            template = generator.get_template(template_name)
+        except Exception:
+            logger.error('[flickrtag]: Unable to find the custom template %s' % template_name)
+            template = Template(default_template)
+    else:
+        template = Template(default_template)
+
+    logger.info('[flickrtag]: Inserting photo information into pages...')
+    for page in generator.pages:
+        for match in flickr_regex.findall(page._content):
+            fid = match[1]
+            if fid not in photo_mapping:
+                logger.error('[flickrtag]: Could not find info for a photo!')
+                continue
+
+            # Create a context to render with
+            context = generator.context.copy()
+            context.update(photo_mapping[fid])
+
+            # Render the template
+            replacement = template.render(context)
+
+            page._content = page._content.replace(match[0], replacement)
 
 
 def register():

--- a/pelican_flickrtag/plugin.py
+++ b/pelican_flickrtag/plugin.py
@@ -135,8 +135,8 @@ def generic_replace(generator, ct_type):
             except:
                 photo_mapping[id] = {
                     'title': "Placeholder",
-                    'raw_url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_PICT')
-                    'url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_LINK')
+                    'raw_url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_PICT'),
+                    'url': generator.context.get('FLICKR_TAG_PLACE_HOLDER_LINK'),
                 }
 
         with open(tmp_file, 'w') as f:

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import pelican_flickrtag
-
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
@@ -32,7 +30,7 @@ requires = [
 
 setup(
     name='pelican-flickrtag',
-    version=pelican_flickrtag.__version__,
+    version='0.5.0',
     description='Display Flickr images easily in your Pelican articles.',
     long_description=readme,
     author='Chris Streeter',


### PR DESCRIPTION
The proposed flickr tag was implemented for articles only. We implemented a generic replacer taking a type of content as a second parameter. Calls to replace_{article,page}_tags now call the generic replacer in order to do the job for pages too. Tested on pelican 3.5.0
